### PR TITLE
Move source/luneta/app.d to source/app.d

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,9 +4,6 @@
 	"authors": [
 		"Felipe Beline Baravieira"
 	],
-	"targetType": "executable",
-	"importPaths": ["source/luneta"],
-	"sourcePaths": ["source/luneta"],
 	"copyright": "Copyright © 2020, Felipe Beline Baravieira",
 	"dependencies": {
 		"fuzzyd": "2.1.2-beta",

--- a/source/app.d
+++ b/source/app.d
@@ -1,5 +1,3 @@
-module luneta.app;
-
 import std.stdio;
 import std.string;
 import std.getopt;


### PR DESCRIPTION
This helps dub auto-detect that this is a executable or a library. It also automatically excludes the app.d file when being used as a library or when running unittests.

It should also help with auto completion with DCD because it will map module names to folder paths, so before it would try to search in source/luneta/luneta/... because /path/to/source/luneta/ was already assumed to be just a source path.